### PR TITLE
fix for kodi-community-addons/plugin.audio.spotify#90

### DIFF
--- a/resources/lib/httpproxy.py
+++ b/resources/lib/httpproxy.py
@@ -116,15 +116,20 @@ class Root:
             return self.send_audio_stream(track_id, filesize, wave_header, range_l)
     track._cp_config = {'response.stream': True}
 
+    def kill_spotty(self):
+        self.spotty_bin.terminate()
+        self.spotty_bin = None
+
     def send_audio_stream(self, track_id, filesize, wave_header, range_l):
         '''chunked transfer of audio data from spotty binary'''
-        log_msg("start transfer for track %s - range: %s" % (track_id, range_l), xbmc.LOGDEBUG)
-
         if self.spotty_bin != None:
-            # If spotty still processing some data don't launch another
-            # This may have only been happening with timeouts that were too short.
-            return
-        
+            # If spotty binary still attached, try to terminate it.
+            log_msg("WHOOPS!!! Running spotty detected - killing it to continue.", \
+                    xbmc.LOGERROR)
+            self.kill_spotty()
+
+        log_msg("start transfer for track %s - range: %s" % (track_id, range_l), \
+                xbmc.LOGDEBUG)
         try:
             # Initialize some loop vars
             max_buffer_size = 524288
@@ -162,9 +167,9 @@ class Root:
         finally:
             # make sure spotty always gets terminated
             if self.spotty_bin != None:
-                self.spotty_bin.terminate()
-                self.spotty_bin = None
-            log_msg("FINISH transfer for track %s - range %s" % (track_id, range_l), xbmc.LOGDEBUG)
+                self.kill_spotty()
+            log_msg("FINISH transfer for track %s - range %s" % (track_id, range_l), \
+                    xbmc.LOGDEBUG)
 
     @cherrypy.expose
     def silence(self, duration, **kwargs):


### PR DESCRIPTION
Fix for long spotify tracks going silent after 7 or 8 mins. All changes in httpproxy.py.

1. Cherrypy timeout increased to be greater than the duration of the track being played. Otherwise, player falls out of the read/write loop when time out detected. Default timeout is 300 secs and the session is then cleaned up by a background task which could take 2 or 3 more minutes getting to the reported 7-8 mins.
1. If timeout does happen, parallel spotty_bin processes could end up running in parallel. Add logic to prevent that.
1. Tracks, especially long ones, can be fetched as multiple partial chunks. The silence filling loop at the end of the player's read/write process prevents spotty_bin from exiting so a new file chunk can be processed (without allowing parallel spotty_bin threads). Also writes silence to the end of the track - the original problem symptom.

With this fix in place, I've been playing spotify tracks ranging from 1-20 minutes without problem.

Thanks for the work on this plugin. Kodi with this plugin is now my preferred player for integrating my local FLAC lib with spotify!


