### PR TITLE
Fixed 'NoneType' object has no attribute 'stop' error when closing Kodi

### DIFF
--- a/resources/lib/main_service.py
+++ b/resources/lib/main_service.py
@@ -115,7 +115,7 @@ class MainService:
         kill_spotty()
         self.proxy_runner.stop()
         self.connect_player.close()
-        self.connect_daemon.stop()
+        self.stop_connect_daemon()
         del self.connect_player
         del self.addon
         del self.kodimonitor


### PR DESCRIPTION
Fixed error when closing Kodi and connect_daemon was not run.
-----
Error Type: <type 'exceptions.AttributeError'>
Error Contents: 'NoneType' object has no attribute 'stop'