### PR TITLE
Prevent infinite loop on "Error Contents: XBMC is not playing any file" exception

### DIFF
--- a/resources/lib/player_monitor.py
+++ b/resources/lib/player_monitor.py
@@ -53,11 +53,9 @@ class ConnectPlayer(xbmc.Player):
         # set the connect_playing bool to indicate we are playing spotify connect content
         self.__is_paused = False
         filename = ""
-        while not filename:
-            try:
-                filename = self.getPlayingFile()
-            except:
-                xbmc.sleep(500)
+        if self.isPlaying():
+            filename = self.getPlayingFile()
+            
         if "localhost:%s" % PROXY_PORT in filename:
             if not self.connect_playing and "connect=true" in filename:
                 # we started playback with (remote) connect player


### PR DESCRIPTION
Prevent infinite loop on "Error Contents: XBMC is not playing any file" exception.
self.getPlayingFile() may cause exception and start infinite loop.