### PR TITLE
Next track display improvement for Spotify Connect playback

### DIFF
--- a/resources/lib/player_monitor.py
+++ b/resources/lib/player_monitor.py
@@ -102,8 +102,10 @@ class ConnectPlayer(xbmc.Player):
             url = "http://localhost:%s/nexttrack" % PROXY_PORT
         else:
             url = "plugin://plugin.audio.spotify/?action=next_track"
-        self.__playlist.add(url)
-        self.__playlist.add(url)
+        
+        li = xbmcgui.ListItem('...', path=url)
+        self.__playlist.add(url, li)
+        self.__playlist.add(url, li)
 
     def start_playback(self, track_id):
         self.__skip_events = True

--- a/resources/lib/plugin_content.py
+++ b/resources/lib/plugin_content.py
@@ -308,8 +308,9 @@ class PluginContent():
                     playlsit = xbmc.PlayList(xbmc.PLAYLIST_MUSIC)
                     playlsit.clear()
                     playlsit.add(url, li)
-                    url = "plugin://plugin.audio.spotify/?action=next_track"
-                    playlsit.add(url)
+                    next_url = "plugin://plugin.audio.spotify/?action=next_track"
+                    next_li = xbmcgui.ListItem("...", path=next_url)
+                    playlsit.add(next_url, next_li)
                     xbmc.Player().play()
                 else:
                     # launch our special OSD dialog


### PR DESCRIPTION
Show "Next: ..." instead of "Next: plugin://plugin.audio.spotify/?action=next_track" while playing on Spotify Connect.